### PR TITLE
Make electron apps use wayland by default

### DIFF
--- a/os/components/environment.nix
+++ b/os/components/environment.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+	environment.sessionVariables = {
+		"NIXOS_OZONE_WL" = "1";
+	};
+}

--- a/os/os.nix
+++ b/os/os.nix
@@ -8,6 +8,7 @@
 		./components/bluetooth.nix
 		./components/boot.nix
 		./components/display.nix
+		./components/environment.nix
 		./components/file-system.nix
 		./components/fonts.nix
 		./components/gnome.nix


### PR DESCRIPTION
Enables wayland support for multiple chrome apps

May break:
- Chrome
- VSCode
- GitKraken
- Insomnia
- Bootstrap Studio
- Etcher
- Obsidian