### PR TITLE
Remove polkit, since gnome bundles polkit

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -20,7 +20,6 @@
 		# Services
 		./services/configure-camera.nix # Configures camera on startup
 		./services/flameshot.nix        # Screenshot tool
-		./services/polkit.nix           # Policy kit graphical agent
 		./services/rclone.nix           # Cloud sync daemon
 		./services/syncthing.nix        # Cross-device file synchronization
 
@@ -110,7 +109,6 @@
 		hsetroot                     # Wallpaper setter
 		libsForQt5.okular            # PDF editor
 		pavucontrol                  # Audio configuration helper
-		polkit_gnome                 # Policy kit agent
 		shotwell                     # Image viewer
 		v4l-utils                    # Video input adjuster
 		yaru-theme                   # GTK theme


### PR DESCRIPTION
Polkit was originally added in https://github.com/khrj/nixos-config/commit/c8da16d5824d72df7ff9e00b527ab967d1709144 due to i3, which was added in in https://github.com/khrj/nixos-config/commit/7fb09f13055e4572a2175861427eb1a495a4cdf7, but was subsequently removed in https://github.com/khrj/nixos-config/commit/4a250554779b836d17c2c4269beac9fc153e1346